### PR TITLE
Feature/fix today widget in dark mode

### DIFF
--- a/NewsWidget/Base.lproj/MainInterface.storyboard
+++ b/NewsWidget/Base.lproj/MainInterface.storyboard
@@ -1,18 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="bif-Jq-892">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="bif-Jq-892">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="HelveticaNeue.ttc">
-            <string>HelveticaNeue</string>
-        </array>
-    </customFonts>
     <scenes>
         <!--TodayWidget-->
         <scene sceneID="6eZ-R8-ekF">
@@ -21,19 +14,18 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" sectionHeaderHeight="-1" sectionFooterHeight="-1" id="NJ6-SD-fGY">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="180"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="tableCell" rowHeight="41" id="X2u-51-6eg" customClass="TodayEntryCell" customModule="Today" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="320" height="41"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X2u-51-6eg" id="6Lw-ck-tsQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="40.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="41"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WxD-z9-k7m">
-                                            <rect key="frame" x="8" y="4" width="304" height="33"/>
+                                            <rect key="frame" x="8" y="4" width="304" height="33.5"/>
                                             <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -59,7 +51,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="T2U-fH-XIR" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="533" y="47"/>
+            <point key="canvasLocation" x="772.46376811594212" y="31.473214285714285"/>
         </scene>
     </scenes>
 </document>

--- a/NewsWidget/TodayViewController.swift
+++ b/NewsWidget/TodayViewController.swift
@@ -127,8 +127,8 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 
 		initSettings()
 		
-        // "Set Theme"
-        selectedCellBackground.backgroundColor = Colors.TodayWidget.selectedBackground
+		// "Set Theme"
+		selectedCellBackground.backgroundColor = Colors.TodayWidget.selectedBackground
 
 		setLoadingIndicator()
 		
@@ -136,7 +136,7 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
     }
 	
 	func setLoadingIndicator() {
-        loadingIndicator.color = Colors.TodayWidget.tint
+		loadingIndicator.color = Colors.TodayWidget.tint
 		loadingIndicator.frame = CGRect(x: 0.0, y: 0.0, width: 10.0, height: 10.0)
 		loadingIndicator.center = self.view.center
 		self.view.addSubview(loadingIndicator)
@@ -271,7 +271,7 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 
         let tableItem: Entry = entries[indexPath.row] as Entry
         cell.entryTitle.text = tableItem.title
-        cell.entryTitle.textColor = Colors.TodayWidget.label
+		cell.entryTitle.textColor = Colors.TodayWidget.label
 		cell.selectedBackgroundView = selectedCellBackground
 		
 		Shared.hideWhiteSpaceBeforeCell(tableView, cell: cell)
@@ -340,7 +340,7 @@ fileprivate enum Colors {
         }
         
         static var tint: UIColor { UIColor(red: 171.0/255.0, green: 97.0/255.0, blue: 23.0/255.0, alpha: 1.0) }
-
+        
         static var label : UIColor {
             guard #available(iOS 10.0, *) else {
                 // in iOS 8-9 widget background is black
@@ -350,7 +350,7 @@ fileprivate enum Colors {
                 // In iOS 10+ widget background is light grey
                 return .black
             }
-
+            
             return UIColor.label
         }
     }

--- a/NewsWidget/TodayViewController.swift
+++ b/NewsWidget/TodayViewController.swift
@@ -332,15 +332,26 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 // MARK: - Today Widget colors
 fileprivate enum Colors {
     enum TodayWidget {
-        static var selectedBackground: UIColor { UIColor.darkGray }
+        static var selectedBackground: UIColor {
+            guard #available(iOS 13, *)
+                else { return UIColor.darkGray }
+            
+            return UIColor.systemGray3
+        }
+        
         static var tint: UIColor { UIColor(red: 171.0/255.0, green: 97.0/255.0, blue: 23.0/255.0, alpha: 1.0) }
+
         static var label : UIColor {
-            // In iOS 19 widget background is light grey
-            if #available(iOS 10.0, *) {
-                return .black
-            } else {
-                return UIColor(white: 0.98, alpha: 1.0)
+            guard #available(iOS 10.0, *) else {
+                // in iOS 8-9 widget background is black
+                return UIColor(white: 0.98, alpha: 1)
             }
+            guard #available(iOS 13.0, *) else {
+                // In iOS 10+ widget background is light grey
+                return .black
+            }
+
+            return UIColor.label
         }
     }
 }

--- a/NewsWidget/TodayViewController.swift
+++ b/NewsWidget/TodayViewController.swift
@@ -108,11 +108,7 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 	let loadingIndicator:UIActivityIndicatorView = UIActivityIndicatorView  (style: UIActivityIndicatorView.Style.whiteLarge)
 	var loading = false
 	
-	// Theme colors
-	let textColorLight = UIColor(red: 250.0/255.0, green: 250.0/255.0, blue: 250.0/255.0, alpha: 1)
-	let textColorDark = UIColor(red: 0.0/255.0, green: 0.0/255.0, blue: 0.0/255.0, alpha: 1)
 	var selectedCellBackground = UIView()
-	let tintColor = UIColor(red: 171.0/255.0, green: 97.0/255.0, blue: 23.0/255.0, alpha: 1.0)
 	
 	// localization
 	let errorTitle: String = NSLocalizedString("ERROR", comment: "Title for error alert")
@@ -130,19 +126,17 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
         }
 
 		initSettings()
-		setTheme()
 		
+        // "Set Theme"
+        selectedCellBackground.backgroundColor = Colors.TodayWidget.selectedBackground
+
 		setLoadingIndicator()
 		
 		initView()
     }
 	
-	func setTheme() {
-		selectedCellBackground.backgroundColor = UIColor.darkGray
-	}
-	
 	func setLoadingIndicator() {
-		loadingIndicator.color = tintColor
+        loadingIndicator.color = Colors.TodayWidget.tint
 		loadingIndicator.frame = CGRect(x: 0.0, y: 0.0, width: 10.0, height: 10.0)
 		loadingIndicator.center = self.view.center
 		self.view.addSubview(loadingIndicator)
@@ -277,13 +271,7 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 
         let tableItem: Entry = entries[indexPath.row] as Entry
         cell.entryTitle.text = tableItem.title
-		// In iOS 19 widget background is light grey
-		if #available(iOS 10.0, *) {
-			cell.entryTitle.textColor = textColorDark
-		} else {
-			cell.entryTitle.textColor = textColorLight
-		}
-		
+        cell.entryTitle.textColor = Colors.TodayWidget.label
 		cell.selectedBackgroundView = selectedCellBackground
 		
 		Shared.hideWhiteSpaceBeforeCell(tableView, cell: cell)
@@ -339,4 +327,20 @@ class TodayViewController: UITableViewController, NCWidgetProviding {
 //    deinit {
 //        NSNotificationCenter.defaultCenter().removeObserver(self)
 //    }
+}
+
+// MARK: - Today Widget colors
+fileprivate enum Colors {
+    enum TodayWidget {
+        static var selectedBackground: UIColor { UIColor.darkGray }
+        static var tint: UIColor { UIColor(red: 171.0/255.0, green: 97.0/255.0, blue: 23.0/255.0, alpha: 1.0) }
+        static var label : UIColor {
+            // In iOS 19 widget background is light grey
+            if #available(iOS 10.0, *) {
+                return .black
+            } else {
+                return UIColor(white: 0.98, alpha: 1.0)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes the Today Widget colors especially in iOS 13 dark mode.

It additionally contains 
  - a small refactoring to extract the widget color selection logic to its own "component"
  - change to the today widget storyboard to not set background white.

